### PR TITLE
fix(api): curry plus and concat

### DIFF
--- a/src/concat.ts
+++ b/src/concat.ts
@@ -1,14 +1,22 @@
+import curry from './curry'
+
 /**
  * Concatenates arrays or strings.
  *
  * @example
  * concat([1,2], [3,4]) // [1,2,3,4]
  */
-function concat<T>(left: T[], right: T[]): T[]
-function concat(left: string, right: string): string
-
-function concat(left: any, right: any) {
-  return left.concat(right)
+const concatRaw = <T>(left: T[] | string, right: T[] | string) => {
+  return (left as any).concat(right as any)
 }
+
+type Concat = {
+  <T>(left: T[], right: T[]): T[]
+  <T>(left: T[]): (right: T[]) => T[]
+  (left: string, right: string): string
+  (left: string): (right: string) => string
+}
+
+const concat = /*#__PURE__*/ curry(concatRaw) as Concat
 
 export default concat

--- a/src/plus.ts
+++ b/src/plus.ts
@@ -1,6 +1,8 @@
+import curry from './curry'
+
 /**
  * Adds two numbers.
  */
 const plus = (a: number, b: number) => a + b
 
-export default plus
+export default /*#__PURE__*/ curry(plus)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -96,6 +96,9 @@ describe('tikka exports', () => {
   it('concat', () => {
     expect(concat([1, 2], [3, 4])).toEqual([1, 2, 3, 4])
     expect(concat('ab', 'cd')).toBe('abcd')
+
+    expect((concat as any)([1, 2])([3, 4])).toEqual([1, 2, 3, 4])
+    expect((concat as any)('ab')('cd')).toBe('abcd')
   })
 
   it('contains and includes', () => {
@@ -264,6 +267,9 @@ describe('tikka exports', () => {
     expect(plus(2, 3)).toBe(5)
     expect(sum(2, 3)).toBe(5)
     expect(minus(3, 10)).toBe(7)
+
+    expect((plus as any)(2)(3)).toBe(5)
+    expect((sum as any)(2)(3)).toBe(5)
   })
 
   it('noop', () => {


### PR DESCRIPTION
## Summary
- make `plus` curried
- make `concat` curried
- add test coverage for curried invocation of both APIs

## Audit
Searched for exported multi-arg functions that were not wrapped in `curry`/`curryRight`. Found exactly two: `plus` and `concat`.

## Verification
- `npm run typecheck`
- `npm test`